### PR TITLE
Migrate confirmation to planbuilder except for map

### DIFF
--- a/client/components/Activities/ActivityItem.js
+++ b/client/components/Activities/ActivityItem.js
@@ -6,7 +6,8 @@ export default class ActivityItem extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      modalOpen: false
+      modalOpen: false,
+      buttonClicked: false
     };
   }
 
@@ -14,6 +15,13 @@ export default class ActivityItem extends Component {
     this.setState({
       modalOpen: !this.state.modalOpen
     });
+  }
+
+  ClickButton() {
+    this.setState({
+      buttonClicked: true
+    });
+    this.props.onAddToBuilderClicked();
   }
 
   render() {
@@ -37,9 +45,9 @@ export default class ActivityItem extends Component {
           </div>
         </Modal>
         <button
-          onClick={this.props.onAddToBuilderClicked}
-          disabled={activity.added ? 'disabled' : ''}>
-          {activity.added ? 'Added' : 'Add to itinerary'}
+          onClick={this.ClickButton.bind(this)}
+          disabled={this.state.buttonClicked ? 'disabled' : ''}>
+          {this.state.buttonClicked ? 'Added' : 'Add to itinerary'}
         </button>
       </div>
     )

--- a/client/components/Activities/PlanBuilderContainer.js
+++ b/client/components/Activities/PlanBuilderContainer.js
@@ -1,6 +1,10 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
-import { confirmPlan, deleteFromBuilder } from '../../redux/actions'
+import { confirmPlan, 
+        deleteFromBuilder, 
+        reorderUp, 
+        reorderDown, 
+        changingRoutes } from '../../redux/actions'
 import { buildPlanner } from '../../redux/reducers'
 import PlanBuilderItem from './PlanBuilderItem'
 
@@ -25,7 +29,15 @@ class PlanBuilderContainer extends Component {
           <PlanBuilderItem
             key={activity.title}
             activity={activity}
-            onDeleteFromBuilderClicked={() => this.props.deleteFromBuilder(activity)}/>
+            onDeleteFromBuilderClicked={() => this.props.deleteFromBuilder(activity)}
+            onMoveUpClicked={() => {
+              this.props.reorderUp(activities.indexOf(activity));
+              changingRoutes(activities);
+            }}
+            onMoveDownClicked={() => {
+              this.props.reorderDown(activities.indexOf(activity));
+              changingRoutes(activities);
+            }}/>
         )}
         </div>
       </div>
@@ -61,5 +73,5 @@ const mapStateToProps = (state) => {
 
 export default connect(
   mapStateToProps,
-  { confirmPlan, deleteFromBuilder }
+  { confirmPlan, deleteFromBuilder, reorderUp, reorderDown, changingRoutes }
 )(PlanBuilderContainer)

--- a/client/components/Activities/PlanBuilderItem.js
+++ b/client/components/Activities/PlanBuilderItem.js
@@ -10,7 +10,14 @@ export default class PlanBuilderItem extends Component {
                 borderStyle: "solid",
                 borderWidth: "2px" }}>
         <div> {activity.title} - {activity.desc} {activity.location } </div>
-
+        <button
+          onClick={this.props.onMoveUpClicked}>
+          Up
+        </button>
+        <button
+          onClick={this.props.onMoveDownClicked}>
+          Down
+        </button>
         <button
           onClick={this.props.onDeleteFromBuilderClicked}>
           Delete


### PR DESCRIPTION
Can move items up/down on planbuilder.
'Add to itinerary' button will disable after adding activity
