### PR TITLE
(planBuilder) fixed problem with reordering up/down

### DIFF
--- a/client/components/Activities/PlanBuilderContainer.js
+++ b/client/components/Activities/PlanBuilderContainer.js
@@ -50,12 +50,12 @@ class PlanBuilderContainer extends Component {
             openSnackbar={this.props.openSnackbar}
             onDeleteFromBuilderClicked={() => this.props.deleteFromBuilder(activity)}
             onMoveUpClicked={() => {
-              this.props.reorderUp(activities.indexOf(activity));
-              changingRoutes(activities);
+              this.props.reorderUp(planBuilder.indexOf(activity));
+              changingRoutes(planBuilder);
             }}
             onMoveDownClicked={() => {
-              this.props.reorderDown(activities.indexOf(activity));
-              changingRoutes(activities);
+              this.props.reorderDown(planBuilder.indexOf(activity));
+              changingRoutes(planBuilder);
             }}/>
         )}
         </div>


### PR DESCRIPTION
Previously reordering up/down would make all activities appear on the map. Now only planbuilder activities show up.
